### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@
 
 A Model Context Protocol server that provides web content fetching capabilities using Playwright for browser automation. This server enables LLMs to retrieve and process JavaScript-rendered content from web pages, converting HTML to markdown for easier consumption.
 
+<a href="https://glama.ai/mcp/servers/@ThreatFlux/playwright-fetch">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ThreatFlux/playwright-fetch/badge" alt="Playwright Fetch Server MCP server" />
+</a>
+
 ## Author
 
 Created by [Wyatt Roersma](https://github.com/wyroersma) with assistance from Claude Code.


### PR DESCRIPTION
This PR adds a badge for the [Playwright Fetch MCP Server](https://glama.ai/mcp/servers/@ThreatFlux/playwright-fetch) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ThreatFlux/playwright-fetch">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ThreatFlux/playwright-fetch/badge" alt="Playwright Fetch Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.